### PR TITLE
Add basic WolfSSL detection

### DIFF
--- a/docs/C_LANGUAGE_SUPPORT.md
+++ b/docs/C_LANGUAGE_SUPPORT.md
@@ -33,3 +33,6 @@ mvn clean package
 2. Build SonarCXX as described above and copy the plugin JAR to the SonarQube `extensions/plugins` directory.
 3. Build this repository and copy the resulting `sonar-cryptography-plugin` JAR to the same directory.
 4. Start SonarQube and verify that both plugins appear in **Administration → Marketplace → Installed**.
+## Current limitations
+
+The C and C++ support in this plugin is experimental. A minimal translation layer and detection engine exist but only search for WolfSSL function names such as `wc_AesCbcEncrypt` in the source text. This allows the WolfCrypt detection rules in `c/src/main/java/com/ibm/plugin/rules/detection/wolfcrypt` to trigger on simple cases. Complex C code may still be missed and further integration with a real parser is required for reliable CBOM generation.

--- a/engine/src/main/java/com/ibm/engine/language/c/CxxLanguageTranslation.java
+++ b/engine/src/main/java/com/ibm/engine/language/c/CxxLanguageTranslation.java
@@ -6,19 +6,31 @@ import com.ibm.engine.language.ILanguageTranslation;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
 
 public class CxxLanguageTranslation implements ILanguageTranslation<Object> {
+    private static final Pattern CALL_PATTERN = Pattern.compile("([a-zA-Z0-9_]+)\\s*\\(");
+
     @Nonnull
     @Override
     public Optional<String> getMethodName(@Nonnull MatchContext matchContext, @Nonnull Object methodInvocation) {
+        if (methodInvocation instanceof String call) {
+            Matcher m = CALL_PATTERN.matcher(call);
+            if (m.find()) {
+                return Optional.of(m.group(1));
+            }
+        }
         return Optional.empty();
     }
 
     @Nonnull
     @Override
     public Optional<IType> getInvokedObjectTypeString(@Nonnull MatchContext matchContext, @Nonnull Object methodInvocation) {
-        return Optional.empty();
+        return getMethodName(matchContext, methodInvocation)
+                .filter(name -> name.startsWith("wc_"))
+                .map(name -> (IType) (String s) -> s.equals("wolfssl"));
     }
 
     @Nonnull
@@ -36,6 +48,9 @@ public class CxxLanguageTranslation implements ILanguageTranslation<Object> {
     @Nonnull
     @Override
     public Optional<String> resolveIdentifierAsString(@Nonnull MatchContext matchContext, @Nonnull Object name) {
+        if (name instanceof String s) {
+            return Optional.of(s);
+        }
         return Optional.empty();
     }
 


### PR DESCRIPTION
## Summary
- extend C/C++ translation with simple pattern matching
- implement rudimentary detection engine for WolfSSL calls
- update documentation on C/C++ limitations

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: org.junit:junit-bom)*

------
https://chatgpt.com/codex/tasks/task_e_6889c95392fc8331825801cca14780d0