### PR TITLE
Add basic WolfSSL detection

### DIFF
--- a/c/src/main/java/com/ibm/plugin/rules/CInventoryRule.java
+++ b/c/src/main/java/com/ibm/plugin/rules/CInventoryRule.java
@@ -1,18 +1,13 @@
 package com.ibm.plugin.rules;
 
 import com.ibm.plugin.rules.detection.CBaseDetectionRule;
-import com.ibm.rules.InventoryRule;
-import com.ibm.rules.issue.Issue;
-import com.ibm.mapper.model.INode;
-import java.util.List;
-import javax.annotation.Nonnull;
+import com.ibm.plugin.rules.detection.CDetectionRules;
+import java.util.Collections;
 import org.sonar.check.Rule;
 
 @Rule(key = "Inventory")
 public class CInventoryRule extends CBaseDetectionRule {
-    @Override
-    public @Nonnull List<Issue<Object>> report(
-            @Nonnull Object markerTree, @Nonnull List<INode> nodes) {
-        return new InventoryRule<Object>().report(markerTree, nodes);
+    public CInventoryRule() {
+        super(true, CDetectionRules.rules(), Collections.emptyList());
     }
 }

--- a/c/src/main/java/com/ibm/plugin/rules/detection/CBaseDetectionRule.java
+++ b/c/src/main/java/com/ibm/plugin/rules/detection/CBaseDetectionRule.java
@@ -1,25 +1,81 @@
 package com.ibm.plugin.rules.detection;
 
 import com.ibm.common.IObserver;
+import com.ibm.engine.detection.DetectionStore;
 import com.ibm.engine.detection.Finding;
+import com.ibm.engine.executive.DetectionExecutive;
+import com.ibm.engine.language.c.CxxScanContext;
+import com.ibm.engine.rule.IDetectionRule;
+import com.ibm.mapper.model.INode;
+import com.ibm.mapper.reorganizer.IReorganizerRule;
+import com.ibm.plugin.CAggregator;
+import com.ibm.plugin.translation.CTranslationProcess;
 import com.ibm.rules.IReportableDetectionRule;
+import com.ibm.rules.InventoryRule;
 import com.ibm.rules.issue.Issue;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nonnull;
+import org.sonar.api.batch.fs.InputFile;
 
+/**
+ * Base class for C/C++ rules. It wires the detection engine with the translation
+ * process so that detected findings can be converted into mapper nodes and
+ * ultimately written to the CBOM.
+ */
 public abstract class CBaseDetectionRule
         implements IObserver<Finding<Object, Object, Object, Object>>,
                 IReportableDetectionRule<Object> {
 
+    private final boolean isInventory;
+    @Nonnull protected final CTranslationProcess translationProcess;
+    @Nonnull protected final List<IDetectionRule<Object>> detectionRules;
+
+    protected CBaseDetectionRule() {
+        this(false, CDetectionRules.rules(), Collections.emptyList());
+    }
+
+    protected CBaseDetectionRule(
+            boolean isInventory,
+            @Nonnull List<IDetectionRule<Object>> detectionRules,
+            @Nonnull List<IReorganizerRule> reorganizerRules) {
+        this.isInventory = isInventory;
+        this.detectionRules = detectionRules;
+        this.translationProcess = new CTranslationProcess(reorganizerRules);
+    }
+
+    /**
+     * Scans a file by running all configured detection rules against its
+     * textual content.
+     */
+    public void scanFile(@Nonnull String content, @Nonnull InputFile inputFile) {
+        detectionRules.forEach(
+                rule -> {
+                    DetectionExecutive<Object, Object, Object, Object> exec =
+                            CAggregator.getLanguageSupport()
+                                    .createDetectionExecutive(
+                                            content, rule, new CxxScanContext(inputFile));
+                    exec.subscribe(this);
+                    exec.start();
+                });
+    }
+
     @Override
     public void update(@Nonnull Finding<Object, Object, Object, Object> finding) {
-        // no-op
+        List<INode> nodes = translationProcess.initiate(finding.detectionStore());
+        if (isInventory) {
+            CAggregator.addNodes(nodes);
+        }
+        report(finding.getMarkerTree(), nodes)
+                .forEach(issue ->
+                        finding.detectionStore()
+                                .getScanContext()
+                                .reportIssue(this, issue.tree(), issue.message()));
     }
 
     @Override
     public @Nonnull List<Issue<Object>> report(
-            @Nonnull Object markerTree, @Nonnull List<com.ibm.mapper.model.INode> nodes) {
-        return Collections.emptyList();
+            @Nonnull Object markerTree, @Nonnull List<INode> nodes) {
+        return new InventoryRule<>().report(markerTree, nodes);
     }
 }

--- a/c/src/main/java/com/ibm/plugin/rules/detection/CDetectionRules.java
+++ b/c/src/main/java/com/ibm/plugin/rules/detection/CDetectionRules.java
@@ -1,0 +1,18 @@
+package com.ibm.plugin.rules.detection;
+
+import com.ibm.engine.rule.IDetectionRule;
+import com.ibm.plugin.rules.detection.wolfcrypt.WolfCryptRules;
+import java.util.List;
+import javax.annotation.Nonnull;
+
+/**
+ * Lists all detection rules available for the C/C++ frontend.
+ */
+public final class CDetectionRules {
+    private CDetectionRules() {}
+
+    @Nonnull
+    public static List<IDetectionRule<Object>> rules() {
+        return WolfCryptRules.rules();
+    }
+}

--- a/c/src/main/java/com/ibm/plugin/translation/CTranslationProcess.java
+++ b/c/src/main/java/com/ibm/plugin/translation/CTranslationProcess.java
@@ -1,0 +1,30 @@
+package com.ibm.plugin.translation;
+
+import com.ibm.engine.detection.DetectionStore;
+import com.ibm.mapper.ITranslationProcess;
+import com.ibm.mapper.model.INode;
+import com.ibm.mapper.reorganizer.IReorganizerRule;
+import com.ibm.mapper.reorganizer.Reorganizer;
+import com.ibm.mapper.utils.Utils;
+import com.ibm.plugin.translation.translator.CTranslator;
+import java.util.List;
+import javax.annotation.Nonnull;
+
+public final class CTranslationProcess extends ITranslationProcess<Object, Object, Object, Object> {
+
+    public CTranslationProcess(@Nonnull List<IReorganizerRule> reorganizerRules) {
+        super(reorganizerRules);
+    }
+
+    @Override
+    @Nonnull
+    public List<INode> initiate(@Nonnull DetectionStore<Object, Object, Object, Object> rootDetectionStore) {
+        CTranslator translator = new CTranslator();
+        List<INode> translated = translator.translate(rootDetectionStore);
+        Utils.printNodeTree("translated ", translated);
+        Reorganizer reorganizer = new Reorganizer(reorganizerRules);
+        List<INode> reorganized = reorganizer.reorganize(translated);
+        Utils.printNodeTree("reorganised", reorganized);
+        return reorganized;
+    }
+}

--- a/c/src/main/java/com/ibm/plugin/translation/translator/CTranslator.java
+++ b/c/src/main/java/com/ibm/plugin/translation/translator/CTranslator.java
@@ -1,0 +1,60 @@
+package com.ibm.plugin.translation.translator;
+
+import com.ibm.engine.detection.DetectionStore;
+import com.ibm.mapper.ITranslator;
+import com.ibm.mapper.model.INode;
+import com.ibm.mapper.model.algorithms.AES;
+import com.ibm.mapper.model.algorithms.RSA;
+import com.ibm.mapper.model.algorithms.SHA2;
+import com.ibm.mapper.utils.DetectionLocation;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+
+/**
+ * Very small translator that converts action values produced by detection
+ * rules into algorithm nodes. Only a handful of WolfCrypt algorithms are
+ * supported.
+ */
+public final class CTranslator extends ITranslator<Object, Object, Object, Object> {
+
+    @Nonnull
+    public List<INode> translate(@Nonnull DetectionStore<Object, Object, Object, Object> store) {
+        List<INode> nodes = new ArrayList<>();
+        collect(store, nodes);
+        return nodes;
+    }
+
+    private void collect(DetectionStore<Object, Object, Object, Object> store, List<INode> out) {
+        store.getActionValue()
+                .ifPresent(
+                        action -> {
+                            String value = action.asString();
+                            DetectionLocation loc =
+                                    new DetectionLocation(
+                                            store.getScanContext().getFilePath(),
+                                            1,
+                                            0,
+                                            List.of(value),
+                                            store.getDetectionRule().bundle());
+                            switch (value) {
+                                case "AES" -> out.add(new AES(loc));
+                                case "SHA-256" -> out.add(new SHA2(256, loc));
+                                case "RSA" -> out.add(new RSA(loc));
+                                default -> {
+                                }
+                            }
+                        });
+        store.getChildren().forEach(child -> collect(child, out));
+    }
+
+    @Override
+    public Optional<INode> translate(
+            @Nonnull com.ibm.engine.rule.IBundle bundle,
+            @Nonnull com.ibm.engine.model.IValue<Object> value,
+            @Nonnull com.ibm.engine.model.context.IDetectionContext detectionValueContext,
+            @Nonnull String filePath) {
+        return Optional.empty();
+    }
+}

--- a/docs/C_LANGUAGE_SUPPORT.md
+++ b/docs/C_LANGUAGE_SUPPORT.md
@@ -33,3 +33,6 @@ mvn clean package
 2. Build SonarCXX as described above and copy the plugin JAR to the SonarQube `extensions/plugins` directory.
 3. Build this repository and copy the resulting `sonar-cryptography-plugin` JAR to the same directory.
 4. Start SonarQube and verify that both plugins appear in **Administration → Marketplace → Installed**.
+## Current limitations
+
+The C and C++ support in this plugin is experimental. A minimal translation layer and detection engine exist that perform rough text search and simple function call matching for WolfSSL APIs such as `wc_AesCbcEncrypt`. A dedicated `WolfCrypt` rule set is registered through `CDetectionRules`, and detected WolfSSL primitives are translated into CBOM entries when the **Cryptographic Inventory (CBOM)** rule is enabled. Complex C code may still be missed and further integration with a real parser is required for reliable CBOM generation.

--- a/engine/src/main/java/com/ibm/engine/language/c/CxxDetectionEngine.java
+++ b/engine/src/main/java/com/ibm/engine/language/c/CxxDetectionEngine.java
@@ -3,13 +3,14 @@ package com.ibm.engine.language.c;
 import com.ibm.engine.detection.DetectionStore;
 import com.ibm.engine.detection.Handler;
 import com.ibm.engine.detection.IDetectionEngine;
-import com.ibm.engine.detection.IType;
 import com.ibm.engine.detection.MatchContext;
-import com.ibm.engine.detection.MethodMatcher;
+import com.ibm.engine.detection.MethodDetection;
+import com.ibm.engine.rule.DetectionRule;
+import com.ibm.engine.rule.MethodDetectionRule;
 import com.ibm.engine.rule.Parameter;
 import com.ibm.engine.detection.ResolvedValue;
 import com.ibm.engine.detection.TraceSymbol;
-import com.ibm.engine.executive.DetectionExecutive;
+import com.ibm.engine.language.ILanguageTranslation;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -29,10 +30,47 @@ public class CxxDetectionEngine implements IDetectionEngine<Object, Object> {
     }
 
     @Override
-    public void run(@Nonnull Object tree) {}
+    public void run(@Nonnull Object tree) {
+        run(TraceSymbol.createStart(), tree);
+    }
 
     @Override
-    public void run(@Nonnull TraceSymbol<Object> traceSymbol, @Nonnull Object tree) {}
+    public void run(@Nonnull TraceSymbol<Object> traceSymbol, @Nonnull Object tree) {
+        if (!(tree instanceof String code)) {
+            return;
+        }
+        MatchContext matchContext = MatchContext.build(false, detectionStore.getDetectionRule());
+        ILanguageTranslation<Object> translation = handler.getLanguageSupport().translation();
+
+        if (detectionStore.getDetectionRule().is(MethodDetectionRule.class)) {
+            java.util.regex.Matcher matcher =
+                    java.util.regex.Pattern.compile("([a-zA-Z0-9_]+)\\s*\\(").matcher(code);
+            while (matcher.find()) {
+                String call = matcher.group();
+                if (detectionStore.getDetectionRule().match(call, translation)) {
+                    analyseExpression(call);
+                }
+            }
+            return;
+        }
+
+        if (detectionStore.getDetectionRule().match(code, translation)) {
+            analyseExpression(code);
+        }
+    }
+
+    private void analyseExpression(@Nonnull String expression) {
+        if (detectionStore.getDetectionRule().is(MethodDetectionRule.class)) {
+            MethodDetection<Object> methodDetection = new MethodDetection<>(expression, null);
+            detectionStore.onReceivingNewDetection(methodDetection);
+            return;
+        }
+
+        if (detectionStore.getDetectionRule() instanceof DetectionRule<?> detectionRule && detectionRule.actionFactory() != null) {
+            MethodDetection<Object> methodDetection = new MethodDetection<>(expression, null);
+            detectionStore.onReceivingNewDetection(methodDetection);
+        }
+    }
 
     @Override
     public @Nullable Object extractArgumentFromMethodCaller(

--- a/engine/src/main/java/com/ibm/engine/language/c/CxxLanguageTranslation.java
+++ b/engine/src/main/java/com/ibm/engine/language/c/CxxLanguageTranslation.java
@@ -6,19 +6,31 @@ import com.ibm.engine.language.ILanguageTranslation;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
 
 public class CxxLanguageTranslation implements ILanguageTranslation<Object> {
+    private static final Pattern CALL_PATTERN = Pattern.compile("([a-zA-Z0-9_]+)\\s*\\(");
+
     @Nonnull
     @Override
     public Optional<String> getMethodName(@Nonnull MatchContext matchContext, @Nonnull Object methodInvocation) {
+        if (methodInvocation instanceof String call) {
+            Matcher m = CALL_PATTERN.matcher(call);
+            if (m.find()) {
+                return Optional.of(m.group(1));
+            }
+        }
         return Optional.empty();
     }
 
     @Nonnull
     @Override
     public Optional<IType> getInvokedObjectTypeString(@Nonnull MatchContext matchContext, @Nonnull Object methodInvocation) {
-        return Optional.empty();
+        return getMethodName(matchContext, methodInvocation)
+                .filter(name -> name.startsWith("wc_"))
+                .map(name -> (IType) (String s) -> s.equals("wolfssl"));
     }
 
     @Nonnull
@@ -36,6 +48,9 @@ public class CxxLanguageTranslation implements ILanguageTranslation<Object> {
     @Nonnull
     @Override
     public Optional<String> resolveIdentifierAsString(@Nonnull MatchContext matchContext, @Nonnull Object name) {
+        if (name instanceof String s) {
+            return Optional.of(s);
+        }
         return Optional.empty();
     }
 


### PR DESCRIPTION
## Summary
- wire WolfCrypt detection rules into the C inventory rule
- translate WolfSSL findings into CBOM nodes through a minimal translation layer
- document that WolfCrypt detections now populate CBOM when the Inventory rule is active

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: org.junit:junit-bom)*

------
https://chatgpt.com/codex/tasks/task_e_6889c95392fc8331825801cca14780d0