### PR TITLE
Detect WolfCrypt AES usage in C as crypto asset

### DIFF
--- a/c/src/main/java/com/ibm/plugin/rules/detection/wolfcrypt/WolfCryptRules.java
+++ b/c/src/main/java/com/ibm/plugin/rules/detection/wolfcrypt/WolfCryptRules.java
@@ -32,7 +32,11 @@ public final class WolfCryptRules {
                             "wc_AesCbcEncrypt",
                             "wc_AesCbcDecrypt",
                             "wc_AesEncrypt",
-                            "wc_AesDecrypt")
+                            "wc_AesDecrypt",
+                            "wc_AesGcmEncrypt",
+                            "wc_AesGcmDecrypt",
+                            "wc_AesCtrEncrypt",
+                            "wc_AesCtrDecrypt")
                     .shouldBeDetectedAs(new ValueActionFactory<>("AES"))
                     .withAnyParameters()
                     .buildForContext(new CipherContext())

--- a/c/src/test/java/com/ibm/plugin/rules/detection/wolfcrypt/WolfCryptAESTest.java
+++ b/c/src/test/java/com/ibm/plugin/rules/detection/wolfcrypt/WolfCryptAESTest.java
@@ -1,0 +1,64 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2024 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.plugin.rules.detection.wolfcrypt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ibm.mapper.model.INode;
+import com.ibm.mapper.model.algorithms.AES;
+import com.ibm.plugin.CAggregator;
+import com.ibm.plugin.rules.CInventoryRule;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.sonar.api.batch.fs.InputFile;
+import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
+
+class WolfCryptAESTest {
+
+    @TempDir Path tempDir;
+
+    @BeforeEach
+    void setUp() {
+        CAggregator.reset();
+    }
+
+    @Test
+    void detectsAesUsageAsAsset() {
+        String code =
+                "void test(){ wc_AesGcmEncrypt(0,0,0,0,0,0,0,0,0); }";
+
+        InputFile inputFile =
+                TestInputFileBuilder.create("moduleKey", "test.c")
+                        .setModuleBaseDir(tempDir)
+                        .setLanguage("c")
+                        .setContents(code)
+                        .build();
+
+        CInventoryRule rule = new CInventoryRule();
+        rule.scanFile(code, inputFile);
+
+        List<INode> nodes = CAggregator.getDetectedNodes();
+        assertThat(nodes.stream().anyMatch(n -> n instanceof AES)).isTrue();
+    }
+}
+


### PR DESCRIPTION
## Summary
- recognize additional WolfCrypt AES APIs when scanning C sources
- add unit test verifying AES detection is treated as a cryptographic asset

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-checkstyle-plugin:3.6.0 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6894e665b8288331a8976380f7b6d8d9