### PR TITLE
Add OpenSSL AES detection for C

### DIFF
--- a/c/src/main/java/com/ibm/plugin/rules/detection/CDetectionRules.java
+++ b/c/src/main/java/com/ibm/plugin/rules/detection/CDetectionRules.java
@@ -1,7 +1,9 @@
 package com.ibm.plugin.rules.detection;
 
 import com.ibm.engine.rule.IDetectionRule;
+import com.ibm.plugin.rules.detection.openssl.OpenSslRules;
 import com.ibm.plugin.rules.detection.wolfcrypt.WolfCryptRules;
+import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
 
@@ -13,6 +15,9 @@ public final class CDetectionRules {
 
     @Nonnull
     public static List<IDetectionRule<Object>> rules() {
-        return WolfCryptRules.rules();
+        List<IDetectionRule<Object>> rules = new ArrayList<>();
+        rules.addAll(WolfCryptRules.rules());
+        rules.addAll(OpenSslRules.rules());
+        return rules;
     }
 }

--- a/c/src/main/java/com/ibm/plugin/rules/detection/openssl/OpenSslRules.java
+++ b/c/src/main/java/com/ibm/plugin/rules/detection/openssl/OpenSslRules.java
@@ -1,0 +1,37 @@
+package com.ibm.plugin.rules.detection.openssl;
+
+import com.ibm.engine.model.context.CipherContext;
+import com.ibm.engine.model.factory.ValueActionFactory;
+import com.ibm.engine.rule.IDetectionRule;
+import com.ibm.engine.rule.builder.DetectionRuleBuilder;
+import java.util.List;
+import javax.annotation.Nonnull;
+
+public final class OpenSslRules {
+    private OpenSslRules() {}
+
+    private static final String LIB_TYPE = "openssl";
+
+    private static final IDetectionRule<Object> AES_RULE =
+            new DetectionRuleBuilder<Object>()
+                    .createDetectionRule()
+                    .forObjectTypes(LIB_TYPE)
+                    .forMethods(
+                            "AES_encrypt",
+                            "AES_decrypt",
+                            "AES_cbc_encrypt",
+                            "AES_ecb_encrypt",
+                            "AES_ctr128_encrypt",
+                            "AES_set_encrypt_key",
+                            "AES_set_decrypt_key")
+                    .shouldBeDetectedAs(new ValueActionFactory<>("AES"))
+                    .withAnyParameters()
+                    .buildForContext(new CipherContext())
+                    .inBundle(() -> "OpenSSL")
+                    .withoutDependingDetectionRules();
+
+    @Nonnull
+    public static List<IDetectionRule<Object>> rules() {
+        return List.of(AES_RULE);
+    }
+}

--- a/c/src/test/java/com/ibm/plugin/rules/detection/openssl/OpenSslAESTest.java
+++ b/c/src/test/java/com/ibm/plugin/rules/detection/openssl/OpenSslAESTest.java
@@ -1,0 +1,62 @@
+/*
+ * Sonar Cryptography Plugin
+ * Copyright (C) 2024 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.plugin.rules.detection.openssl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ibm.mapper.model.INode;
+import com.ibm.mapper.model.algorithms.AES;
+import com.ibm.plugin.CAggregator;
+import com.ibm.plugin.rules.CInventoryRule;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.sonar.api.batch.fs.InputFile;
+import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
+
+class OpenSslAESTest {
+
+    @TempDir Path tempDir;
+
+    @BeforeEach
+    void setUp() {
+        CAggregator.reset();
+    }
+
+    @Test
+    void detectsAesUsageAsAsset() {
+        String code = "void test(){ AES_encrypt(0,0,0); }";
+
+        InputFile inputFile =
+                TestInputFileBuilder.create("moduleKey", "test.c")
+                        .setModuleBaseDir(tempDir)
+                        .setLanguage("c")
+                        .setContents(code)
+                        .build();
+
+        CInventoryRule rule = new CInventoryRule();
+        rule.scanFile(code, inputFile);
+
+        List<INode> nodes = CAggregator.getDetectedNodes();
+        assertThat(nodes.stream().anyMatch(n -> n instanceof AES)).isTrue();
+    }
+}

--- a/engine/src/main/java/com/ibm/engine/language/c/CxxLanguageTranslation.java
+++ b/engine/src/main/java/com/ibm/engine/language/c/CxxLanguageTranslation.java
@@ -40,8 +40,16 @@ public class CxxLanguageTranslation implements ILanguageTranslation<Object> {
     @Override
     public Optional<IType> getInvokedObjectTypeString(@Nonnull MatchContext matchContext, @Nonnull Object methodInvocation) {
         return getMethodName(matchContext, methodInvocation)
-                .filter(name -> name.startsWith("wc_"))
-                .map(name -> (IType) (String s) -> s.equals("wolfssl"));
+                .flatMap(
+                        name -> {
+                            if (name.startsWith("wc_")) {
+                                return Optional.of((IType) (String s) -> s.equals("wolfssl"));
+                            }
+                            if (name.startsWith("AES_")) {
+                                return Optional.of((IType) (String s) -> s.equals("openssl"));
+                            }
+                            return Optional.empty();
+                        });
     }
 
     @Nonnull


### PR DESCRIPTION
## Summary
- detect OpenSSL AES API calls in C sources
- allow engine to map AES_* functions to the OpenSSL library type
- test AES detection through a new OpenSSL inventory test

## Testing
- `mvn -q -Dcheckstyle.skip=true test` *(fails: Plugin org.apache.maven.plugins:maven-checkstyle-plugin:pom:3.6.0 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68956d7334048331ac57e25e6209d072