### PR TITLE
chore: add debug trace for python cbom

### DIFF
--- a/python/src/main/java/com/ibm/plugin/rules/detection/PythonBaseDetectionRule.java
+++ b/python/src/main/java/com/ibm/plugin/rules/detection/PythonBaseDetectionRule.java
@@ -23,6 +23,7 @@ import com.ibm.common.IObserver;
 import com.ibm.engine.detection.Finding;
 import com.ibm.engine.executive.DetectionExecutive;
 import com.ibm.engine.language.python.PythonScanContext;
+import com.ibm.engine.utils.DetectionStoreLogger;
 import com.ibm.engine.rule.IDetectionRule;
 import com.ibm.mapper.model.INode;
 import com.ibm.mapper.reorganizer.IReorganizerRule;
@@ -34,6 +35,8 @@ import com.ibm.rules.issue.Issue;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nonnull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonVisitorCheck;
 import org.sonar.plugins.python.api.PythonVisitorContext;
@@ -44,6 +47,9 @@ import org.sonar.plugins.python.api.tree.Tree;
 public abstract class PythonBaseDetectionRule extends PythonVisitorCheck
         implements IObserver<Finding<PythonCheck, Tree, Symbol, PythonVisitorContext>>,
                 IReportableDetectionRule<Tree> {
+
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(PythonBaseDetectionRule.class);
 
     private final boolean isInventory;
     @Nonnull protected final PythonTranslationProcess pythonTranslationProcess;
@@ -89,7 +95,16 @@ public abstract class PythonBaseDetectionRule extends PythonVisitorCheck
      */
     @Override
     public void update(@Nonnull Finding<PythonCheck, Tree, Symbol, PythonVisitorContext> finding) {
+        LOGGER.debug(
+                "Detected finding for {}", this.getClass().getSimpleName());
+        new DetectionStoreLogger<PythonCheck, Tree, Symbol, PythonVisitorContext>()
+                .print(finding.detectionStore());
+
         List<INode> nodes = pythonTranslationProcess.initiate(finding.detectionStore());
+        LOGGER.debug(
+                "Translated finding for {} into {} nodes",
+                this.getClass().getSimpleName(),
+                nodes.size());
         if (isInventory) {
             PythonAggregator.addNodes(nodes);
         }

--- a/python/src/main/java/com/ibm/plugin/translation/PythonTranslationProcess.java
+++ b/python/src/main/java/com/ibm/plugin/translation/PythonTranslationProcess.java
@@ -30,6 +30,8 @@ import com.ibm.plugin.translation.translator.PythonTranslator;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nonnull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonVisitorContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
@@ -37,6 +39,9 @@ import org.sonar.plugins.python.api.tree.Tree;
 
 public final class PythonTranslationProcess
         extends ITranslationProcess<PythonCheck, Tree, Symbol, PythonVisitorContext> {
+
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(PythonTranslationProcess.class);
 
     public PythonTranslationProcess(@Nonnull List<IReorganizerRule> reorganizerRules) {
         super(reorganizerRules);
@@ -48,6 +53,7 @@ public final class PythonTranslationProcess
             @Nonnull
                     DetectionStore<PythonCheck, Tree, Symbol, PythonVisitorContext>
                             rootDetectionStore) {
+        LOGGER.debug("Starting translation of Python detection store");
         // 1. Translate
         final PythonTranslator pythonTranslator = new PythonTranslator();
         final List<INode> translatedValues = pythonTranslator.translate(rootDetectionStore);
@@ -61,7 +67,7 @@ public final class PythonTranslationProcess
         // 3. Enrich
         final List<INode> enrichedValues = Enricher.enrich(reorganizedValues).stream().toList();
         Utils.printNodeTree("  enriched  ", enrichedValues);
-
+        LOGGER.debug("Translation completed with {} enriched nodes", enrichedValues.size());
         return Collections.unmodifiableCollection(enrichedValues).stream().toList();
     }
 }

--- a/sonar-cryptography-plugin/src/main/java/com/ibm/plugin/OutputFileJob.java
+++ b/sonar-cryptography-plugin/src/main/java/com/ibm/plugin/OutputFileJob.java
@@ -21,7 +21,10 @@ package com.ibm.plugin;
 
 import com.ibm.output.cyclondx.CBOMOutputFileFactory;
 import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 import javax.annotation.Nonnull;
+import com.ibm.mapper.model.INode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sonar.api.batch.postjob.PostJob;
@@ -45,6 +48,20 @@ public class OutputFileJob implements PostJob {
                         .orElse(Constants.CBOM_OUTPUT_NAME_DEFAULT);
         ScannerManager scannerManager = new ScannerManager(new CBOMOutputFileFactory());
         final File cbom = new File(cbomFilename + ".json");
+
+        List<INode> nodes = new ArrayList<>();
+        nodes.addAll(JavaAggregator.getDetectedNodes());
+        nodes.addAll(PythonAggregator.getDetectedNodes());
+        nodes.addAll(CAggregator.getDetectedNodes());
+        nodes.forEach(
+                node ->
+                        LOGGER.debug(
+                                "Writing ({}) {} to CBOM",
+                                node.getKind().getSimpleName(),
+                                node.asString()));
+        scannerManager.getStatistics().print(LOGGER::debug);
+
+        LOGGER.debug("Saving CBOM to '{}'", cbom.getAbsolutePath());
         scannerManager.getOutputFile().saveTo(cbom);
         LOGGER.info("CBOM was successfully generated '{}'.", cbom.getAbsolutePath());
         scannerManager.getStatistics().print(LOGGER::info);


### PR DESCRIPTION
## Summary
- add detailed debug logging around Python detection and translation
- log every asset written to the generated CBOM

## Testing
- `mvn -q -pl sonar-cryptography-plugin -am test` *(fails: Unresolveable build extension)*
- `mvn -q test` *(fails: maven-checkstyle-plugin: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689728791da48331bb9a628de1cf1457