### PR TITLE
feat: add CBOM consolidation for C detections

### DIFF
--- a/c/src/main/java/com/ibm/plugin/translation/CTranslationProcess.java
+++ b/c/src/main/java/com/ibm/plugin/translation/CTranslationProcess.java
@@ -1,6 +1,7 @@
 package com.ibm.plugin.translation;
 
 import com.ibm.engine.detection.DetectionStore;
+import com.ibm.enricher.Enricher;
 import com.ibm.mapper.ITranslationProcess;
 import com.ibm.mapper.model.INode;
 import com.ibm.mapper.reorganizer.IReorganizerRule;
@@ -22,9 +23,14 @@ public final class CTranslationProcess extends ITranslationProcess<Object, Objec
         CTranslator translator = new CTranslator();
         List<INode> translated = translator.translate(rootDetectionStore);
         Utils.printNodeTree("translated ", translated);
+
         Reorganizer reorganizer = new Reorganizer(reorganizerRules);
         List<INode> reorganized = reorganizer.reorganize(translated);
         Utils.printNodeTree("reorganised", reorganized);
-        return reorganized;
+
+        List<INode> enriched = Enricher.enrich(reorganized).stream().toList();
+        Utils.printNodeTree("enriched   ", enriched);
+
+        return enriched;
     }
 }

--- a/c/src/main/java/com/ibm/plugin/translation/translator/CTranslator.java
+++ b/c/src/main/java/com/ibm/plugin/translation/translator/CTranslator.java
@@ -11,7 +11,6 @@ import com.ibm.mapper.model.algorithms.RSA;
 import com.ibm.mapper.model.algorithms.SHA2;
 import com.ibm.mapper.utils.DetectionLocation;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nonnull;
@@ -25,34 +24,6 @@ import org.sonar.api.batch.fs.InputFile;
  */
 public final class CTranslator extends ITranslator<Object, Object, Object, Object> {
 
-    @Nonnull
-    public List<INode> translate(@Nonnull DetectionStore<Object, Object, Object, Object> store) {
-        List<INode> nodes = new ArrayList<>();
-        collect(store, nodes);
-        return nodes;
-    }
-
-    private void collect(DetectionStore<Object, Object, Object, Object> store, List<INode> out) {
-        store.getActionValue()
-                .ifPresent(
-                        action -> {
-                            DetectionLocation loc =
-                                    getDetectionContextFrom(
-                                            store,
-                                            store.getDetectionRule().bundle(),
-                                            store.getScanContext().getFilePath());
-                            String value = action.asString();
-                            switch (value) {
-                                case "AES" -> out.add(new AES(loc));
-                                case "SHA-256" -> out.add(new SHA2(256, loc));
-                                case "RSA" -> out.add(new RSA(loc));
-                                default -> {
-                                }
-                            }
-                        });
-        store.getChildren().forEach(child -> collect(child, out));
-    }
-
     @Override
     public Optional<INode> translate(
             @Nonnull IBundle bundle,
@@ -60,7 +31,7 @@ public final class CTranslator extends ITranslator<Object, Object, Object, Objec
             @Nonnull IDetectionContext detectionValueContext,
             @Nonnull String filePath) {
         DetectionLocation detectionLocation =
-                getDetectionContextFrom(value.asString(), bundle, filePath);
+                getDetectionContextFrom(value.getLocation(), bundle, filePath);
         if (detectionLocation == null) {
             return Optional.empty();
         }
@@ -75,22 +46,14 @@ public final class CTranslator extends ITranslator<Object, Object, Object, Objec
     }
 
     @Override
-    @Nullable
     protected DetectionLocation getDetectionContextFrom(
             @Nonnull Object location, @Nonnull IBundle bundle, @Nonnull String filePath) {
-        return new DetectionLocation(filePath, 1, 0, List.of(String.valueOf(location)), bundle);
-    }
-
-    @Override
-    protected DetectionLocation getDetectionContextFrom(
-            @Nonnull Object location, @Nonnull com.ibm.engine.rule.IBundle bundle, @Nonnull String filePath) {
         if (location instanceof DetectionStore<?, ?, ?, ?> store) {
-            String keyword =
-                    store.getActionValue().map(av -> av.asString()).orElse("");
+            String keyword = store.getActionValue().map(av -> av.asString()).orElse("");
             int line = 1;
             int column = 0;
             try {
-                InputFile inputFile = ((DetectionStore<?, ?, ?, ?>) location).getScanContext().getInputFile();
+                InputFile inputFile = store.getScanContext().getInputFile();
                 String content = inputFile.contents();
                 int index = keyword.isEmpty() ? -1 : content.indexOf(keyword);
                 if (index >= 0) {


### PR DESCRIPTION
## Summary
- enhance C translator to rely on generic translation and proper detection locations
- enrich C translation process with reorganization and enrichment for CBOM output

## Testing
- `mvn -q test` *(fails: Unresolveable build extension: org.sonarsource.sonar-packaging-maven-plugin:1.23.0.740)*
- `cd c && mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-checkstyle-plugin:3.6.0 could not be resolved: Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_68981927c824833195eaa1c8de4dc6e5