### PR TITLE
Enable C detection for plain-text function calls

### DIFF
--- a/engine/src/main/java/com/ibm/engine/language/c/CxxDetectionEngine.java
+++ b/engine/src/main/java/com/ibm/engine/language/c/CxxDetectionEngine.java
@@ -55,12 +55,12 @@ public class CxxDetectionEngine implements IDetectionEngine<Object, Object> {
         }
 
         if (tree instanceof String content) {
-            Pattern callPattern = Pattern.compile("[a-zA-Z0-9_]+\\s*\\([^;]*\\)");
+            Pattern callPattern = Pattern.compile("\\b[a-zA-Z_][a-zA-Z0-9_]*\\s*\\(");
             Matcher matcher = callPattern.matcher(content);
             while (matcher.find()) {
-                String call = matcher.group();
-                if (detectionStore.getDetectionRule().match(call, translation)) {
-                    analyseExpression(call);
+                String callStart = matcher.group();
+                if (detectionStore.getDetectionRule().match(callStart, translation)) {
+                    analyseExpression(callStart);
                 }
             }
         }

--- a/engine/src/main/java/com/ibm/engine/language/c/CxxDetectionEngine.java
+++ b/engine/src/main/java/com/ibm/engine/language/c/CxxDetectionEngine.java
@@ -17,6 +17,8 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -38,19 +40,29 @@ public class CxxDetectionEngine implements IDetectionEngine<Object, Object> {
 
     @Override
     public void run(@Nonnull TraceSymbol<Object> traceSymbol, @Nonnull Object tree) {
-        if (!(tree instanceof AstNode root)) {
-            return;
-        }
-
         ILanguageTranslation<Object> translation = handler.getLanguageSupport().translation();
 
-        if (detectionStore.getDetectionRule().is(MethodDetectionRule.class)) {
-            traverseCallNodes(root, translation);
+        if (tree instanceof AstNode root) {
+            if (detectionStore.getDetectionRule().is(MethodDetectionRule.class)) {
+                traverseCallNodes(root, translation);
+                return;
+            }
+
+            if (detectionStore.getDetectionRule().match(root, translation)) {
+                analyseExpression(root);
+            }
             return;
         }
 
-        if (detectionStore.getDetectionRule().match(root, translation)) {
-            analyseExpression(root);
+        if (tree instanceof String content) {
+            Pattern callPattern = Pattern.compile("[a-zA-Z0-9_]+\\s*\\([^;]*\\)");
+            Matcher matcher = callPattern.matcher(content);
+            while (matcher.find()) {
+                String call = matcher.group();
+                if (detectionStore.getDetectionRule().match(call, translation)) {
+                    analyseExpression(call);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Support scanning raw C source strings for function-call patterns in `CxxDetectionEngine`
- Detect AES usage in WolfCrypt/OpenSSL examples without requiring AST parsing

## Testing
- `mvn -q -Dcheckstyle.skip=true -Dtest=com.ibm.plugin.rules.detection.wolfcrypt.WolfCryptAESTest test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-checkstyle-plugin:pom:3.6.0)*

------
https://chatgpt.com/codex/tasks/task_e_6898cec71fac8331a8b31789dad6b571