### PR TITLE
feat: add debug traces for Python CBOM pipeline

### DIFF
--- a/output/src/main/java/com/ibm/output/Constants.java
+++ b/output/src/main/java/com/ibm/output/Constants.java
@@ -27,4 +27,7 @@ public final class Constants {
 
     public static final String SCANNER_NAME = "Sonar Cryptography Plugin";
     public static final String SCANNER_VENDOR = "IBM";
+
+    // Tag used to identify debug traces produced by the plugin
+    public static final String DEBUG_TAG = "[CBOM-DEBUG]";
 }

--- a/python/src/main/java/com/ibm/plugin/PythonAggregator.java
+++ b/python/src/main/java/com/ibm/plugin/PythonAggregator.java
@@ -23,6 +23,7 @@ import com.ibm.engine.language.ILanguageSupport;
 import com.ibm.engine.language.LanguageSupporter;
 import com.ibm.mapper.model.INode;
 import com.ibm.output.IAggregator;
+import com.ibm.output.Constants;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -31,12 +32,15 @@ import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonVisitorContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.plugins.python.api.tree.Tree;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class PythonAggregator implements IAggregator {
 
     private static ILanguageSupport<PythonCheck, Tree, Symbol, PythonVisitorContext>
             pythonLanguageSupport = LanguageSupporter.pythonLanguageSupporter();
     private static List<INode> detectedNodes = new ArrayList<>();
+    private static final Logger LOGGER = LoggerFactory.getLogger(PythonAggregator.class);
 
     private PythonAggregator() {
         // nothing
@@ -54,6 +58,7 @@ public final class PythonAggregator implements IAggregator {
     }
 
     public static void addNodes(@Nonnull List<INode> newNodes) {
+        LOGGER.debug("{} Accumulating {} node(s)", Constants.DEBUG_TAG, newNodes.size());
         detectedNodes.addAll(newNodes);
         IAggregator.log(newNodes);
     }

--- a/python/src/main/java/com/ibm/plugin/rules/detection/PythonBaseDetectionRule.java
+++ b/python/src/main/java/com/ibm/plugin/rules/detection/PythonBaseDetectionRule.java
@@ -34,6 +34,9 @@ import com.ibm.rules.issue.Issue;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nonnull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.ibm.output.Constants;
 import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonVisitorCheck;
 import org.sonar.plugins.python.api.PythonVisitorContext;
@@ -48,6 +51,7 @@ public abstract class PythonBaseDetectionRule extends PythonVisitorCheck
     private final boolean isInventory;
     @Nonnull protected final PythonTranslationProcess pythonTranslationProcess;
     @Nonnull protected final List<IDetectionRule<Tree>> detectionRules;
+    private static final Logger LOGGER = LoggerFactory.getLogger(PythonBaseDetectionRule.class);
 
     protected PythonBaseDetectionRule() {
         this.isInventory = false;
@@ -76,6 +80,10 @@ public abstract class PythonBaseDetectionRule extends PythonVisitorCheck
                                                     tree,
                                                     rule,
                                                     new PythonScanContext(this.getContext()));
+                    LOGGER.debug(
+                            "{} Executing detection rule {}",
+                            Constants.DEBUG_TAG,
+                            rule.getClass().getSimpleName());
                     detectionExecutive.subscribe(this);
                     detectionExecutive.start();
                 });
@@ -89,8 +97,13 @@ public abstract class PythonBaseDetectionRule extends PythonVisitorCheck
      */
     @Override
     public void update(@Nonnull Finding<PythonCheck, Tree, Symbol, PythonVisitorContext> finding) {
+        LOGGER.debug("{} Initiating translation of finding", Constants.DEBUG_TAG);
         List<INode> nodes = pythonTranslationProcess.initiate(finding.detectionStore());
+        LOGGER.debug(
+                "{} Translation produced {} node(s)", Constants.DEBUG_TAG, nodes.size());
         if (isInventory) {
+            LOGGER.debug(
+                    "{} Adding {} node(s) to aggregator", Constants.DEBUG_TAG, nodes.size());
             PythonAggregator.addNodes(nodes);
         }
         // report

--- a/sonar-cryptography-plugin/src/main/java/com/ibm/plugin/OutputFileJob.java
+++ b/sonar-cryptography-plugin/src/main/java/com/ibm/plugin/OutputFileJob.java
@@ -45,6 +45,10 @@ public class OutputFileJob implements PostJob {
                         .orElse(Constants.CBOM_OUTPUT_NAME_DEFAULT);
         ScannerManager scannerManager = new ScannerManager(new CBOMOutputFileFactory());
         final File cbom = new File(cbomFilename + ".json");
+        LOGGER.debug(
+                "{} Saving CBOM to {}",
+                com.ibm.output.Constants.DEBUG_TAG,
+                cbom.getAbsolutePath());
         scannerManager.getOutputFile().saveTo(cbom);
         LOGGER.info("CBOM was successfully generated '{}'.", cbom.getAbsolutePath());
         scannerManager.getStatistics().print(LOGGER::info);


### PR DESCRIPTION
## Summary
- add `[CBOM-DEBUG]` tag for tracing
- log Python rule detection, translation, and aggregation
- log CBOM file generation path

## Testing
- `mvn -q -pl output,python,sonar-cryptography-plugin -am test` *(failed: Unresolveable build extension: sonar-packaging-maven-plugin)*
- `mvn -q test` in `output` *(failed: maven-checkstyle-plugin could not be resolved)*
- `mvn -q test` in `python` *(failed: maven-checkstyle-plugin could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_6899aef3fc688331affe8b5fcf26f50a