### PR TITLE
Harvest C++ crypto calls from scanner report

### DIFF
--- a/sonar-cryptography-plugin/pom.xml
+++ b/sonar-cryptography-plugin/pom.xml
@@ -41,12 +41,34 @@
               <version>2.0.0-SNAPSHOT</version>
               <scope>compile</scope>
           </dependency>
-          <dependency>
-              <groupId>org.json</groupId>
-              <artifactId>json</artifactId>
-              <version>20240303</version>
-          </dependency>
-      </dependencies>
+      <dependency>
+          <groupId>org.json</groupId>
+          <artifactId>json</artifactId>
+          <version>20240303</version>
+      </dependency>
+
+      <!-- SonarQube Plugin API -->
+      <dependency>
+          <groupId>org.sonarsource.sonar-plugin-api</groupId>
+          <artifactId>sonar-plugin-api</artifactId>
+          <version>10.6.0.213</version>
+          <scope>provided</scope>
+      </dependency>
+
+      <!-- Scanner protocol to read .scannerwork/scanner-report/*.pb -->
+      <dependency>
+          <groupId>org.sonarsource.scanner.protocol</groupId>
+          <artifactId>sonar-scanner-protocol</artifactId>
+          <version>10.6.0.213</version>
+      </dependency>
+
+      <!-- JSON support for cbom writer/mapping -->
+      <dependency>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+          <version>2.17.2</version>
+      </dependency>
+  </dependencies>
 
     <build>
         <resources>

--- a/sonar-cryptography-plugin/src/main/java/com/ibm/crypto/CryptoCbomWriter.java
+++ b/sonar-cryptography-plugin/src/main/java/com/ibm/crypto/CryptoCbomWriter.java
@@ -1,0 +1,35 @@
+package com.ibm.crypto;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+public class CryptoCbomWriter {
+  public void writeCbomJson(File out, List<CryptoInventoryCollector.Entry> entries) throws IOException {
+    ObjectNode root = JsonNodeFactory.instance.objectNode();
+    root.put("version", "1.0");
+    ArrayNode assets = root.putArray("assets");
+    for (CryptoInventoryCollector.Entry e : entries) {
+      ObjectNode a = assets.addObject();
+      a.put("file", e.file);
+      a.put("function", e.function);
+      a.put("library", e.library);
+      a.put("primitive", e.primitive);
+      a.put("purpose", e.purpose);
+      if (e.line != null && e.line > 0) {
+        a.put("line", e.line);
+      }
+    }
+    try (OutputStreamWriter w = new OutputStreamWriter(new FileOutputStream(out), StandardCharsets.UTF_8)) {
+      new ObjectMapper().writerWithDefaultPrettyPrinter().writeValue(w, root);
+    }
+  }
+}

--- a/sonar-cryptography-plugin/src/main/java/com/ibm/crypto/CryptoInventoryCollector.java
+++ b/sonar-cryptography-plugin/src/main/java/com/ibm/crypto/CryptoInventoryCollector.java
@@ -1,0 +1,34 @@
+package com.ibm.crypto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CryptoInventoryCollector {
+  public static final class Entry {
+    public final String file;
+    public final String function;
+    public final String library;
+    public final String primitive;
+    public final String purpose;
+    public final Integer line;
+
+    public Entry(String file, String function, String library, String primitive, String purpose, Integer line) {
+      this.file = file;
+      this.function = function;
+      this.library = library;
+      this.primitive = primitive;
+      this.purpose = purpose;
+      this.line = line;
+    }
+  }
+
+  private final List<Entry> entries = new ArrayList<>();
+
+  public void recordCryptoUse(String file, String function, String lib, String primitive, String purpose, Integer line) {
+    entries.add(new Entry(file, function, lib, primitive, purpose, line));
+  }
+
+  public List<Entry> snapshot() {
+    return List.copyOf(entries);
+  }
+}

--- a/sonar-cryptography-plugin/src/main/java/com/ibm/crypto/cxx/CryptoFunctionRegistry.java
+++ b/sonar-cryptography-plugin/src/main/java/com/ibm/crypto/cxx/CryptoFunctionRegistry.java
@@ -1,0 +1,37 @@
+package com.ibm.crypto.cxx;
+
+import java.util.Map;
+
+public final class CryptoFunctionRegistry {
+  public static final class CryptoFn {
+    public final String lib;
+    public final String primitive;
+    public final String purpose;
+    public CryptoFn(String lib, String primitive, String purpose) {
+      this.lib = lib;
+      this.primitive = primitive;
+      this.purpose = purpose;
+    }
+  }
+
+  // Exact, case-sensitive names
+  public static final Map<String, CryptoFn> MAP = Map.ofEntries(
+      // wolfSSL (wolfCrypt)
+      Map.entry("wc_AesSetKey", new CryptoFn("wolfssl", "AES", "key_setup")),
+      Map.entry("wc_AesCbcEncrypt", new CryptoFn("wolfssl", "AES-CBC", "encrypt")),
+      Map.entry("wc_AesCbcDecrypt", new CryptoFn("wolfssl", "AES-CBC", "decrypt")),
+      Map.entry("wc_Sha256Update", new CryptoFn("wolfssl", "SHA-256", "hash")),
+      Map.entry("wc_RsaPublicEncrypt", new CryptoFn("wolfssl", "RSA", "encrypt")),
+      Map.entry("wc_RsaPrivateDecrypt", new CryptoFn("wolfssl", "RSA", "decrypt")),
+      // OpenSSL EVP
+      Map.entry("EVP_EncryptInit_ex", new CryptoFn("openssl", "EVP", "encrypt_init")),
+      Map.entry("EVP_EncryptUpdate", new CryptoFn("openssl", "EVP", "encrypt")),
+      Map.entry("EVP_EncryptFinal_ex", new CryptoFn("openssl", "EVP", "encrypt_final")),
+      Map.entry("EVP_DigestInit_ex", new CryptoFn("openssl", "EVP-Digest", "hash_init")),
+      // mbedTLS
+      Map.entry("mbedtls_aes_setkey_enc", new CryptoFn("mbedtls", "AES", "key_setup")),
+      Map.entry("mbedtls_aes_crypt_cbc", new CryptoFn("mbedtls", "AES-CBC", "encrypt_decrypt"))
+  );
+
+  private CryptoFunctionRegistry() {}
+}

--- a/sonar-cryptography-plugin/src/main/java/com/ibm/crypto/cxx/CxxCryptoHarvestPostJob.java
+++ b/sonar-cryptography-plugin/src/main/java/com/ibm/crypto/cxx/CxxCryptoHarvestPostJob.java
@@ -1,0 +1,86 @@
+package com.ibm.crypto.cxx;
+
+import com.ibm.crypto.CryptoCbomWriter;
+import com.ibm.crypto.CryptoInventoryCollector;
+import org.sonar.api.batch.postjob.PostJob;
+import org.sonar.api.batch.postjob.PostJobContext;
+import org.sonar.api.batch.postjob.PostJobDescriptor;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
+import org.sonar.scanner.protocol.output.ScannerReport;
+import org.sonar.scanner.protocol.output.ScannerReportReader;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+public class CxxCryptoHarvestPostJob implements PostJob {
+
+  private static final Logger LOG = Loggers.get(CxxCryptoHarvestPostJob.class);
+
+  private final CryptoInventoryCollector collector;
+  private final CryptoCbomWriter cbomWriter;
+
+  public CxxCryptoHarvestPostJob(CryptoInventoryCollector collector, CryptoCbomWriter cbomWriter) {
+    this.collector = collector;
+    this.cbomWriter = cbomWriter;
+  }
+
+  @Override
+  public void describe(PostJobDescriptor descriptor) {
+    descriptor.name("C++ Crypto Inventory Harvester").requirePlugins("cxx");
+  }
+
+  @Override
+  public void execute(PostJobContext context) {
+    File workDir = context.scannerContext().getWorkingDirectory();
+    File reportDir = new File(workDir, "scanner-report");
+    if (!reportDir.isDirectory()) {
+      LOG.debug("No scanner-report dir found; skipping C++ crypto harvest");
+      return;
+    }
+
+    try (ScannerReportReader reader = new ScannerReportReader(reportDir)) {
+      ScannerReport.ComponentsReader components = reader.readComponents();
+      ScannerReport.Component component;
+      while ((component = components.read()) != null) {
+        if (component.getType() != ScannerReport.Component.ComponentType.FILE) {
+          continue;
+        }
+        int fileRef = component.getRef();
+        String filePath = component.getProjectRelativePath();
+
+        Map<Integer, String> symbolNameByRef = new HashMap<>();
+        ScannerReport.SymbolsReader symbolsReader = reader.readSymbols(fileRef);
+        ScannerReport.Symbol symbol;
+        while ((symbol = symbolsReader.read()) != null) {
+          if (symbol.getType() == ScannerReport.Symbol.SymbolType.FUNCTION) {
+            symbolNameByRef.put(symbol.getRef(), symbol.getName());
+          }
+        }
+
+        ScannerReport.ReferencesReader refsReader = reader.readReferences(fileRef);
+        ScannerReport.Reference ref;
+        while ((ref = refsReader.read()) != null) {
+          if (ref.getType() != ScannerReport.Reference.ReferenceType.CALL) {
+            continue;
+          }
+          String calledName = symbolNameByRef.get(ref.getSymbolRef());
+          if (calledName == null) {
+            continue;
+          }
+          CryptoFunctionRegistry.CryptoFn meta = CryptoFunctionRegistry.MAP.get(calledName);
+          if (meta == null) {
+            continue;
+          }
+          int line = ref.hasTextRange() ? ref.getTextRange().getStartLine() : -1;
+          collector.recordCryptoUse(filePath, calledName, meta.lib, meta.primitive, meta.purpose, line);
+        }
+      }
+
+      cbomWriter.writeCbomJson(new File(workDir, "cbom.json"), collector.snapshot());
+    } catch (Exception e) {
+      LOG.error("C++ crypto harvest failed", e);
+    }
+  }
+}

--- a/sonar-cryptography-plugin/src/main/java/com/ibm/plugin/CryptographyPlugin.java
+++ b/sonar-cryptography-plugin/src/main/java/com/ibm/plugin/CryptographyPlugin.java
@@ -24,10 +24,9 @@ import org.sonar.api.utils.log.Loggers;
 import org.sonar.api.Plugin;
 import org.sonar.api.SonarProduct;
 import org.sonar.api.SonarRuntime;
-import com.ibm.crypto.cxx.CxxCheckRegistrar;
-import com.ibm.crypto.cxx.CxxCryptoCbomPostJob;
-import com.ibm.crypto.cxx.CxxRulesDefinition;
-import com.ibm.crypto.cxx.CryptoCxxTapSensor;
+import com.ibm.crypto.CryptoCbomWriter;
+import com.ibm.crypto.CryptoInventoryCollector;
+import com.ibm.crypto.cxx.CxxCryptoHarvestPostJob;
 
 public class CryptographyPlugin implements Plugin {
 
@@ -53,11 +52,11 @@ public class CryptographyPlugin implements Plugin {
                 // python
                 PythonScannerRuleDefinition.class, // Define Rules
                 PythonCheckRegistrar.class, // Register Python rules by sonar-python sensor
-                // c/c++
-                CxxRulesDefinition.class, // Define C/C++ rules
-                CxxCheckRegistrar.class, // Register C/C++ checks
-                CryptoCxxTapSensor.class, // Tap cxx artifacts during scan
-                CxxCryptoCbomPostJob.class // Emit cbom.json after analysis
+                // shared crypto inventory
+                CryptoInventoryCollector.class,
+                CryptoCbomWriter.class,
+                // c/c++ harvesting of scanner report
+                CxxCryptoHarvestPostJob.class
                 );
     }
 }

--- a/sonar-cryptography-plugin/src/test/java/com/ibm/plugin/PluginTest.java
+++ b/sonar-cryptography-plugin/src/test/java/com/ibm/plugin/PluginTest.java
@@ -39,6 +39,6 @@ class PluginTest {
         Plugin.Context context = new PluginContextImpl.Builder().setSonarRuntime(runtime).build();
         CryptographyPlugin plugin = new CryptographyPlugin();
         plugin.define(context);
-        Assertions.assertEquals(8, context.getExtensions().size());
+        Assertions.assertEquals(7, context.getExtensions().size());
     }
 }


### PR DESCRIPTION
## Summary
- add scanner-protocol and JSON dependencies
- harvest C/C++ crypto calls from sonar-cxx scanner-report in a PostJob
- collect crypto usages and write `cbom.json` once from shared collector

## Testing
- `mvn -q -pl sonar-cryptography-plugin test` *(fails: Non-resolvable import POM: org.junit:junit-bom)*

------
https://chatgpt.com/codex/tasks/task_e_68a44e84c51c8331b04fd04bd7e6f009